### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/action.php
+++ b/action.php
@@ -27,7 +27,7 @@ class action_plugin_ac extends DokuWiki_Action_Plugin {
     /**
      * Register handlers
      */
-    function register(&$controller) {
+    function register( Doku_Event_Handler $controller) {
         $controller->register_hook('AJAX_CALL_UNKNOWN', 'BEFORE', $this,
                                    'handle_ajax');
     }

--- a/syntax.php
+++ b/syntax.php
@@ -30,12 +30,12 @@ class syntax_plugin_ac extends DokuWiki_Syntax_Plugin {
                                         'plugin_ac');
     }
 
-    function handle($match, $state, $pos, &$handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler) {
         preg_match('/{{AC::(\w+)(?:>([^}]+))?}}/', $match, $command);
         return array_slice($command, 1);
     }
 
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
         if($mode == 'xhtml') {
             $renderer->doc .= ajax_loader::getLoader('ac', $data);
         }


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
